### PR TITLE
closeListener keyCode change

### DIFF
--- a/packages/app/src/app/components/sandbox/CodeEditor/Tabs/index.js
+++ b/packages/app/src/app/components/sandbox/CodeEditor/Tabs/index.js
@@ -104,7 +104,7 @@ export default class EditorTabs extends React.PureComponent<Props> {
   }
 
   closeListener = e => {
-    if ((e.ctrlKey || e.metaKey) && e.code === 'KeyW') {
+    if ((e.ctrlKey || e.metaKey) && e.keyCode === 87) {
       e.preventDefault();
       const currentPos = this.props.tabs.findIndex(
         t => t.moduleId === this.props.currentModuleId


### PR DESCRIPTION
Change closeListener to evaluate keyCode for W

<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
**What kind of change does this PR introduce?**
https://github.com/CompuIves/codesandbox-client/issues/396
<!-- You can also link to an open issue here -->
**What is the current behavior?**
evaluates `e.code` and not `e.keyCode`
<!-- if this is a feature change -->
**What is the new behavior?**
evaluate `e.keyCode`

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [ ] Tests N/A
- [X] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->
